### PR TITLE
fix: Correction of 5g and 3g types in Android

### DIFF
--- a/android/src/main/kotlin/com/connection_network_type/connection_network_type/ConnectionNetworkTypePlugin.kt
+++ b/android/src/main/kotlin/com/connection_network_type/connection_network_type/ConnectionNetworkTypePlugin.kt
@@ -163,8 +163,18 @@ private  fun getMobileNetworkType(context: Context, connectivityManager: Connect
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
       val telephonyManager = context.getSystemService(Context.TELEPHONY_SERVICE) as TelephonyManager
       val displayInfo = telephonyManager.telephonyDisplayInfo
-      if (displayInfo != null && displayInfo.overrideNetworkType == TelephonyDisplayInfo.OVERRIDE_NETWORK_TYPE_NR_NSA) {
-        return NetworkState.mobile5G.toString()
+      if (displayInfo != null) {
+        val overrideNetworkType = displayInfo.overrideNetworkType
+        // Check for all 5G NSA override types:
+        // - OVERRIDE_NETWORK_TYPE_NR_NSA: Standard 5G NSA
+        // - OVERRIDE_NETWORK_TYPE_NR_NSA_MMWAVE: 5G NSA on mmWave (deprecated in API 31, but may still appear)
+        // - OVERRIDE_NETWORK_TYPE_NR_ADVANCED: Advanced 5G NSA (API 31+), replaces mmWave
+        if (overrideNetworkType == TelephonyDisplayInfo.OVERRIDE_NETWORK_TYPE_NR_NSA ||
+            overrideNetworkType == TelephonyDisplayInfo.OVERRIDE_NETWORK_TYPE_NR_NSA_MMWAVE ||
+            (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
+             overrideNetworkType == TelephonyDisplayInfo.OVERRIDE_NETWORK_TYPE_NR_ADVANCED)) {
+          return NetworkState.mobile5G.toString()
+        }
       }
     }
     return NetworkState.mobile4G.toString()

--- a/android/src/main/kotlin/com/connection_network_type/connection_network_type/ConnectionNetworkTypePlugin.kt
+++ b/android/src/main/kotlin/com/connection_network_type/connection_network_type/ConnectionNetworkTypePlugin.kt
@@ -10,7 +10,6 @@ import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
 import android.os.Build
 import android.telephony.TelephonyManager
-import android.telephony.TelephonyDisplayInfo
 import android.util.Log
 import androidx.annotation.RequiresApi
 import androidx.core.content.ContextCompat
@@ -159,22 +158,22 @@ private  fun getMobileNetworkType(context: Context, connectivityManager: Connect
     return NetworkState.mobile3G.toString()
   }
   if (networkInfo.subtype == TelephonyManager.NETWORK_TYPE_LTE) {
-    // Check if this is 5G NSA by examining telephonyDisplayInfo.overrideNetworkType
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-      val telephonyManager = context.getSystemService(Context.TELEPHONY_SERVICE) as TelephonyManager
-      val displayInfo = telephonyManager.telephonyDisplayInfo
-      if (displayInfo != null) {
-        val overrideNetworkType = displayInfo.overrideNetworkType
-        // Check for all 5G NSA override types:
-        // - OVERRIDE_NETWORK_TYPE_NR_NSA: Standard 5G NSA
-        // - OVERRIDE_NETWORK_TYPE_NR_NSA_MMWAVE: 5G NSA on mmWave (deprecated in API 31, but may still appear)
-        // - OVERRIDE_NETWORK_TYPE_NR_ADVANCED: Advanced 5G NSA (API 31+), replaces mmWave
-        if (overrideNetworkType == TelephonyDisplayInfo.OVERRIDE_NETWORK_TYPE_NR_NSA ||
-            overrideNetworkType == TelephonyDisplayInfo.OVERRIDE_NETWORK_TYPE_NR_NSA_MMWAVE ||
-            (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
-             overrideNetworkType == TelephonyDisplayInfo.OVERRIDE_NETWORK_TYPE_NR_ADVANCED)) {
+    // Check for 5G using NetworkCapabilities when available (API 29+)
+    // This can detect 5G NSA when the network type is LTE
+    // Reference: https://developer.android.com/reference/android/net/NetworkCapabilities#NET_CAPABILITY_NR
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+      try {
+        val network = connectivityManager.activeNetwork
+        val capabilities = connectivityManager.getNetworkCapabilities(network)
+        if (capabilities != null && 
+            capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NR)) {
           return NetworkState.mobile5G.toString()
         }
+      } catch (t: Throwable) {
+        // Defensive: some devices/OS versions may throw when calling newer network APIs
+        // Fall back to 4G if we can't determine 5G capability
+        Log.w("ConnectionNetworkType", "Unable to check 5G capability via NetworkCapabilities, falling back to 4G", t)
+        return NetworkState.unReachable.toString()
       }
     }
     return NetworkState.mobile4G.toString()

--- a/android/src/main/kotlin/com/connection_network_type/connection_network_type/ConnectionNetworkTypePlugin.kt
+++ b/android/src/main/kotlin/com/connection_network_type/connection_network_type/ConnectionNetworkTypePlugin.kt
@@ -10,6 +10,7 @@ import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
 import android.os.Build
 import android.telephony.TelephonyManager
+import android.telephony.TelephonyDisplayInfo
 import android.util.Log
 import androidx.annotation.RequiresApi
 import androidx.core.content.ContextCompat
@@ -151,12 +152,21 @@ private  fun getMobileNetworkType(context: Context, connectivityManager: Connect
           TelephonyManager.NETWORK_TYPE_HSPA,
           TelephonyManager.NETWORK_TYPE_EVDO_B,
           TelephonyManager.NETWORK_TYPE_EHRPD,
+          TelephonyManager.NETWORK_TYPE_TD_SCDMA,
           TelephonyManager.NETWORK_TYPE_HSPAP
   )
   if (networkInfo.subtype in mobile3G_types) {
     return NetworkState.mobile3G.toString()
   }
   if (networkInfo.subtype == TelephonyManager.NETWORK_TYPE_LTE) {
+    // Check if this is 5G NSA by examining telephonyDisplayInfo.overrideNetworkType
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+      val telephonyManager = context.getSystemService(Context.TELEPHONY_SERVICE) as TelephonyManager
+      val displayInfo = telephonyManager.telephonyDisplayInfo
+      if (displayInfo != null && displayInfo.overrideNetworkType == TelephonyDisplayInfo.OVERRIDE_NETWORK_TYPE_NR_NSA) {
+        return NetworkState.mobile5G.toString()
+      }
+    }
     return NetworkState.mobile4G.toString()
   }
   if (networkInfo.subtype == TelephonyManager.NETWORK_TYPE_NR) {

--- a/android/src/main/kotlin/com/connection_network_type/connection_network_type/ConnectionNetworkTypePlugin.kt
+++ b/android/src/main/kotlin/com/connection_network_type/connection_network_type/ConnectionNetworkTypePlugin.kt
@@ -173,7 +173,6 @@ private  fun getMobileNetworkType(context: Context, connectivityManager: Connect
         // Defensive: some devices/OS versions may throw when calling newer network APIs
         // Fall back to 4G if we can't determine 5G capability
         Log.w("ConnectionNetworkType", "Unable to check 5G capability via NetworkCapabilities, falling back to 4G", t)
-        return NetworkState.unReachable.toString()
       }
     }
     return NetworkState.mobile4G.toString()


### PR DESCRIPTION
This PR resolve the following problems:

Android

- The 5G network_type (NETWORK_TYPE_NR) is only valid for 5G SA and not for 5G NSA.
In a lot of countries, the operators have a lot of 5G NSA (Since this uses the 4G infrastructure) antennas, so it's included one check for 5G NSA.
- It's added TD_CDMA check for 3G.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances Android network detection to identify 5G NSA when on LTE and includes `TD_SCDMA` in 3G types.
> 
> - **Android network detection** (`ConnectionNetworkTypePlugin.kt`):
>   - Detect 5G NSA on LTE by checking `NetworkCapabilities.NET_CAPABILITY_NR` (API 29+) with safe fallback to 4G on errors.
>   - Include `TelephonyManager.NETWORK_TYPE_TD_SCDMA` in 3G classification.
>   - Add defensive try/catch and warning log when querying newer network APIs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3dbdf375444dd8581d0ff908c3c03a5321732668. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->