### PR TITLE
Feature/add suport to 5 g nsa detection

### DIFF
--- a/android/src/main/kotlin/com/connection_network_type/connection_network_type/ConnectionNetworkTypePlugin.kt
+++ b/android/src/main/kotlin/com/connection_network_type/connection_network_type/ConnectionNetworkTypePlugin.kt
@@ -10,6 +10,7 @@ import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
 import android.os.Build
 import android.telephony.TelephonyManager
+import android.telephony.TelephonyDisplayInfo
 import android.util.Log
 import androidx.annotation.RequiresApi
 import androidx.core.content.ContextCompat
@@ -158,6 +159,32 @@ private  fun getMobileNetworkType(context: Context, connectivityManager: Connect
     return NetworkState.mobile3G.toString()
   }
   if (networkInfo.subtype == TelephonyManager.NETWORK_TYPE_LTE) {
+    // Check if this is 5G NSA (5G NSA uses 4G infrastructure, so it appears as LTE)
+    // Use TelephonyDisplayInfo to detect 5G NSA (API 30+)
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+      try {
+        val telephonyManager = ContextCompat.getSystemService(context, TelephonyManager::class.java)
+        if (telephonyManager != null) {
+          // Use reflection to access telephonyDisplayInfo (not publicly documented)
+          val displayInfoField = telephonyManager.javaClass.getDeclaredField("telephonyDisplayInfo")
+          displayInfoField.isAccessible = true
+          val displayInfo = displayInfoField.get(telephonyManager) as? TelephonyDisplayInfo
+          
+          if (displayInfo != null) {
+            val overrideNetworkType = displayInfo.overrideNetworkType
+            if (overrideNetworkType == TelephonyDisplayInfo.OVERRIDE_NETWORK_TYPE_NR_NSA ||
+                overrideNetworkType == TelephonyDisplayInfo.OVERRIDE_NETWORK_TYPE_NR_NSA_MMWAVE ||
+                (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
+                 overrideNetworkType == TelephonyDisplayInfo.OVERRIDE_NETWORK_TYPE_NR_ADVANCED)) {
+              return NetworkState.mobile5G.toString()
+            }
+          }
+        }
+      } catch (t: Throwable) {
+        // Reflection may fail on some devices, fall back to 4G
+        Log.w("ConnectionNetworkType", "Unable to check 5G NSA, falling back to 4G", t)
+      }
+    }
     return NetworkState.mobile4G.toString()
   }
   if (networkInfo.subtype == TelephonyManager.NETWORK_TYPE_NR) {

--- a/android/src/main/kotlin/com/connection_network_type/connection_network_type/ConnectionNetworkTypePlugin.kt
+++ b/android/src/main/kotlin/com/connection_network_type/connection_network_type/ConnectionNetworkTypePlugin.kt
@@ -151,6 +151,7 @@ private  fun getMobileNetworkType(context: Context, connectivityManager: Connect
           TelephonyManager.NETWORK_TYPE_HSPA,
           TelephonyManager.NETWORK_TYPE_EVDO_B,
           TelephonyManager.NETWORK_TYPE_EHRPD,
+          TelephonyManager.NETWORK_TYPE_TD_SCDMA,
           TelephonyManager.NETWORK_TYPE_HSPAP
   )
   if (networkInfo.subtype in mobile3G_types) {


### PR DESCRIPTION
### This PR resolve the following problems:

**Android**

- The 5G network_type (NETWORK_TYPE_NR) is only valid for 5G SA and not for 5G NSA.
In a lot of countries, the operators have a lot of 5G NSA (Since this uses the 4G infrastructure) antennas, so it's included one check for 5G NSA.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Detects 5G NSA while on LTE using TelephonyDisplayInfo (API 30+) and adds TD-SCDMA to 3G classification.
> 
> - **Android (network detection)**:
>   - **5G NSA detection**: When `subtype == NETWORK_TYPE_LTE`, checks `TelephonyDisplayInfo.overrideNetworkType` (API 30+) via reflection to classify as `mobile5G` for NSA/advanced cases; logs warning on reflection failure.
>   - **3G classification**: Adds `TelephonyManager.NETWORK_TYPE_TD_SCDMA` to 3G types.
>   - **Imports**: Includes `TelephonyDisplayInfo` and minor related updates in `ConnectionNetworkTypePlugin.kt`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8e316f960ca79364bfd5e2ae2440c259201010e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->